### PR TITLE
Added node_modules to docker ignore.  

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@ tmp/*
 
 ## docker
 .dockerignore
+
+## node
+node_modules


### PR DESCRIPTION
When you `ADD . $APP_ROOT` it overwrites the `node_modules` folder that was built during `yarn install`.  If you don't have a `node_modules` folder on your local machine, it will delete it from the docker image.

[Happy Hacktoberfest](https://hacktoberfest.digitalocean.com/details)